### PR TITLE
Problem: environment awareness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- `single_threaded::tasks` and `single_threaded::queued_tasks` API for executor summary
+- `single_threaded::evict_all` API to permanently remove all current tasks 
+
 ## [0.1.0] - 2021-02-05
 
 Initial release


### PR DESCRIPTION
In certain cases, being aware if there are other tasks, and whether any
of them is queued for execution helps making decisions -- like waiting
for a message from a queue instead of polling.

Solution: introduce `tasks()` and `queued_tasks()` API

While implementing this, I ran into an issue: one of the tests was
locking when running in a true single-threaded environment. The issue
was that another test was leaving an unresolved task, so
`run(None)` was never finishing. This prompted addition of `evict_all()`
to facilitate test execution. I thought that it might have some
practical value in other cases so I made it public.