### PR TITLE
Problem: single-threaded token counter can be exhausted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - `single_threaded::tasks` and `single_threaded::queued_tasks` API for executor summary
 - `single_threaded::evict_all` API to permanently remove all current tasks 
 
+### Fixed
+
+- single-threaded executor's token counter can panic on exhaustion
+
 ## [0.1.0] - 2021-02-05
 
 Initial release


### PR DESCRIPTION
Since tokens are `usize` numbers and the counter is a simple increment,
once it reaches `usize::MAX`, can overflow and panic.

Solution: provide clarity that we always need a wrapping increment

This still means tokens can be reused, but hopefully this number of
tasks is not easy to achieve. If this is not true, a better token
mechanism will need to be devised.