### PR TITLE
Problem: running futures to completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- `single_threaded::block_on` API that allows to block on non-static-lifetime futures
+
 ## [0.2.0] - 2021-02-06
 
 ### Added


### PR DESCRIPTION
Within sync environments, there is a need to run all tasks until a
completion of a certain future. Problem is, these futures often get
non-static lifetime.

Solution: implement `single_threaded::block_on` API

This call takes non-static lifetime futures and *lies* (transmutes)
about its lifetime. The hope is that this is actually ok because we know
that the future will be complete by the end of `block_on`, leaving no
trace of it when it's done.