### PR TITLE
Problem: single-threaded executor starvation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Fixed
+
+- Executor can starve if all tasks went pending
+
 ## [0.3.0] - 2021-02-06
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,4 @@ futures = { version = "0.3.12", features = ["std"] }
 wasm-bindgen-test = "0.3"
 
 [dev-dependencies]
-tokio = { version = "1.1.1", features = ["sync"] }
+tokio = { version = "1.1.1", features = ["sync", "rt"] }


### PR DESCRIPTION
Single-threaded executor can starve if all tasks went pending. This
means it has nothing to run, and nothing will ever change. It'll keep
running forever, spinning and doing nothing.

Solition: when nothing is left to run, requeue all tasks