### PR TITLE
Problem: visibility into the task list

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,6 +37,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
+          args: --all-features
 
   wasm:
     name: WebAssembly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- Debugging capabilities in a form of `single_threaded::task_name` and `single_threaded::tokens`
+
 ## [0.3.1] - 2021-02-06
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,10 @@ wasm-bindgen-test = "0.3"
 
 [dev-dependencies]
 tokio = { version = "1.1.1", features = ["sync", "rt"] }
+
+[features]
+default = []
+debug = []
+
+[package.metadata.docs.rs]
+all-features = true


### PR DESCRIPTION
Sometimes, it's hard to debug without knowing what tasks are actually
running.

Solution: add `tokens()` and `task_type()` API for single-threaded executor

This is only enabled with `debug` feature turned on.