### PR TITLE
Problem: getting queued tokens only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Added
 
-- Debugging capabilities in a form of `single_threaded::task_name` and `single_threaded::tokens`
+- Debugging capabilities in a form of `single_threaded::task_name`, `single_threaded::tokens` and
+  `single_threaded::queued_tokens`
 
 ## [0.3.1] - 2021-02-06
 

--- a/src/single_threaded.rs
+++ b/src/single_threaded.rs
@@ -191,7 +191,7 @@ pub fn queued_tasks() -> usize {
     EXECUTOR.with(|cell| (unsafe { &mut *cell.get() }).queue.len())
 }
 
-/// Returns tokens for all task that haven't completed yet
+/// Returns tokens for all tasks that haven't completed yet
 ///
 /// ## Note
 ///
@@ -199,6 +199,22 @@ pub fn queued_tasks() -> usize {
 #[cfg(feature = "debug")]
 pub fn tokens() -> Vec<Token> {
     EXECUTOR.with(|cell| (unsafe { &*cell.get() }).types.keys().map(|k| *k).collect())
+}
+
+/// Returns tokens for queued tasks
+///
+/// ## Note
+///
+/// Enabled only when `debug` feature is turned on
+#[cfg(feature = "debug")]
+pub fn queued_tokens() -> Vec<Token> {
+    EXECUTOR.with(|cell| {
+        (unsafe { &*cell.get() })
+            .queue
+            .iter()
+            .map(|t| t.token)
+            .collect()
+    })
 }
 
 /// Returns task's future type for a given token


### PR DESCRIPTION
`single_threaded::tokens` API is useful but it does not discriminate
between tokens of tasks that were queued already and those whose
weren't.

Solution: implement `queued_tokens()` function