### PR TITLE
Problem: type information in debug deleted too early

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Fixed
+
+- Type debugging information was removed too early
+
 ## [0.3.2] - 2021-02-06
 
 ### Added


### PR DESCRIPTION
It happens even if the the future was pending

Solution: do it only when the task future is removed