### PR TITLE
Problem: unexpected behaviour of the executor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Type debugging information was removed too early
+- Incorrect future pinning
 
 ## [0.3.2] - 2021-02-06
 


### PR DESCRIPTION
In a "real world" scenario I can see the executor hanging randomly. Not
sure why.

Solution: fix the pinning

The problem was that I was pinning the futures only for the duration of
the poll, once I started pinning them for their lifetime, everything
started working as expected.