### PR TITLE
Problem: double-taking `executor.executing`

### DIFF
--- a/src/single_threaded.rs
+++ b/src/single_threaded.rs
@@ -158,7 +158,6 @@ pub fn run(until: Option<Task>) {
 
                 if let Some(Task { ref token }) = until {
                     if *token == task.token {
-                        (unsafe { &mut *cell.get() }).executing.take();
                         return;
                     }
                 }


### PR DESCRIPTION
This has no effect. This is a remnant of the past structures.

Solution: remove it