### PR TITLE
Problem: interacting with the JavaScript environment of the thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased] - ReleaseDate
 
+## Added
+
+- A way to run the executor cooperatively with the host's JavaScript environment
+  (`single_threaded::run_cooperatively`)
+
 ## [0.4.1] - 2021-02-06
 
 The snapshot of 0.4.0's code was published incorrectly, thus yanked. 0.4.1 replaces it.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ crate-type = ["cdylib","lib"]
 
 [dependencies]
 futures = { version = "0.3.12", features = ["std"] }
+js-sys = { version = "0.3.47", optional = true }
+wasm-bindgen = { version = "0.2.70", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = "0.3"
@@ -25,6 +27,7 @@ tokio = { version = "1.1.1", features = ["sync", "rt"] }
 [features]
 default = []
 debug = []
+cooperative = ["js-sys", "wasm-bindgen"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -9,6 +9,9 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 wasm-bindgen = "0.2.70"
-wasm-rs-async-executor = { path = ".." }
+wasm-rs-async-executor = { path = "..", features = ["cooperative"] }
 wasm-rs-dbg = "0.1"
 tokio = { version = "1.1", features = ["macros", "time", "sync"] }
+wasm-bindgen-futures = "0.4.20"
+web-sys = { version = "0.3.47", features = ["Window", "Response"] }
+js-sys = "0.3.47"

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -1,7 +1,8 @@
-use wasm_rs_dbg::dbg;
-use wasm_rs_async_executor::single_threaded as executor;
 use tokio::sync::oneshot;
 use wasm_bindgen::prelude::*;
+use wasm_bindgen_futures::JsFuture;
+use wasm_rs_async_executor::single_threaded as executor;
+use wasm_rs_dbg::dbg;
 
 #[wasm_bindgen(start)]
 #[allow(unused_variables)]
@@ -18,10 +19,17 @@ pub fn start() {
     let task2 = executor::spawn(async move {
         dbg!("task 2 awaiting");
         let _ = receiver2.await;
+        dbg!("task 2 fetching /");
+        let fut: JsFuture = web_sys::window().unwrap().fetch_with_str("/").into();
+        let response: web_sys::Response = fut.await.unwrap().into();
+        let text_fut: JsFuture = response.text().unwrap().into();
+        let text: String = text_fut.await.unwrap().as_string().unwrap();
+        dbg!(text);
         dbg!("task 2 done");
     });
     dbg!("starting executor, sending to task1");
     let _ = sender1.send(());
-    executor::run(Some(task2));
-    dbg!("execution is complete");
+    unsafe {
+        executor::run_cooperatively(Some(task2));
+    }
 }


### PR DESCRIPTION
Running Rust thread in the browser using `single_threaded::run` locks
the thread for good. One can call JavaScript functions from it but can't
really expect asynchronous APIs to work.

This is not always the most desirable trade-off.

Solution: introduce `run_cooperatively` function

It works the same way as `run`, however, after just one iteration of
processing its task queue, it relinquishes control to JavaScript and
schedules its own execution (provided it has not reached requested
outcome).