### PR TITLE
Problem: run_cooperatively marked as `unsafe`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+- `single_threaded::run_cooperatively` is no longer marked `unsafe`
+  (but this is not a guarantee just yet)
+
 ## [0.5.0] - 2021-02-08
 
-## Added
+### Added
 
 - A way to run the executor cooperatively with the host's JavaScript environment
   (`single_threaded::run_cooperatively`)

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -29,7 +29,5 @@ pub fn start() {
     });
     dbg!("starting executor, sending to task1");
     let _ = sender1.send(());
-    unsafe {
-        executor::run_cooperatively(Some(task2));
-    }
+    executor::run_cooperatively(Some(task2));
 }

--- a/src/single_threaded.rs
+++ b/src/single_threaded.rs
@@ -207,15 +207,8 @@ extern "C" {
 /// JavaScript event loop to proceed.
 ///
 /// This function is available under `cooperative` feature gate.
-///
-/// ## Caution
-///
-/// This is an **unsafe** function because it relies on the caling code (or, rather, it's author)
-/// to ensure that all of the spawned tasks are in fact `'static` as they can't contain any stack
-/// references. The tasks must own their data.
-///
 #[cfg(feature = "cooperative")]
-pub unsafe fn run_cooperatively(until: Option<Task>) {
+pub fn run_cooperatively(until: Option<Task>) {
     if !run_max(until.clone(), Some(1)) {
         set_timeout(Closure::once_into_js(|| run_cooperatively(until)));
     }


### PR DESCRIPTION
Now, I am not 100% sure it *is* safe -- simply because I've only spent a
few days on this library.

I've published it as `unsafe` at first because I do remember transmuting
some futures into a static lifetime somewhere higher up in the code :)

But the reality is that `spawn` itself requires task's future to be
of static lifetime. Which is how it is in `wasm-bindgen-future`. Which
is how it *should be*.

The only time we're actually extending lifetime is when we block on a
future to run it to completion under the assumption that since it will
run to completion at that point, it is safe to do so (whether I am
actually correct is something to be seen)

Solution: remove the `unsafe` marker

It doesn't 100% guarantee I am right, but this is the best I can come up
with right now.