### PR TITLE
Problem: hard to test cooperative execution

### DIFF
--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -29,5 +29,10 @@ pub fn start() {
     });
     dbg!("starting executor, sending to task1");
     let _ = sender1.send(());
-    executor::run_cooperatively(Some(task2));
+    executor::run_cooperatively(
+        Some(task2),
+        Some(|| {
+            dbg!("Done");
+        }),
+    );
 }


### PR DESCRIPTION
This is because it relies on a scheduler outside of our domain
(JavaScript)

Solution: allow to run a callback after the queue is exhausted

This changes `single_threaded::run_cooperatively` type signature a bit,
adding an extra parameter.

The testing is still not perfect as we can't really ensure the callback
was called, but if it *was*, then we can run the assertions.

This can be alternatively done by something like `join_all` for all
futures representing tasks scheduled and spawning another task to do
something after they've been joined, but it seems at the time that
adding this callback has lower impact / easier ergonomics (but, of
course, it's less "pure" if you may)