### PR TITLE
Problem: lack of specificity about required Rust version

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        toolchain: ['1.49.0', 'stable', 'nightly']
+        toolchain: ['1.49.0', '1.50.0', 'stable', 'nightly']
 
     steps:
       - name: Checkout sources

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Include this dependency in your `Cargo.toml`:
 wasm-rs-async-executor = "0.5.1"
 ```
 
+`wasm-rs-async-executor` is expected to work on stable Rust, 1.49.0 and higher up. It *may* also
+work on earlier versions. This hasn't been tested yet.
+
 ## Notes
 
 Please note that this library hasn't received much analysis in terms of safety

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,4 @@
+[toolchain]
+targets = ["wasm32-unknown-unknown"]
+components = ["rustfmt", "clippy"]
+channel = "stable"

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,21 @@
+let
+  moz_overlay = import (builtins.fetchTarball https://github.com/mozilla/nixpkgs-mozilla/archive/master.tar.gz);
+  pkgs = import <nixpkgs> { overlays = [ moz_overlay ]; };
+  rustChannel = (pkgs.rustChannelOf { channel = "stable";  });
+  rust = (rustChannel.rust.override {
+    targets = ["wasm32-unknown-unknown"];
+  });
+in
+pkgs.stdenv.mkDerivation rec {
+  name = "wasm-rs-async-channel-shell";
+
+  buildInputs = with pkgs; [ rust nodejs
+                             openssl.dev pkgconfig # for cargo-release
+  ];
+
+  shellHook = ''
+    # Useful for ensuring cargo tools are available (like cargo-do, for example)
+    export PATH=$PATH:$HOME/.cargo/bin
+  '';
+
+}


### PR DESCRIPTION
Solution: specify that it should run on stable

Also, expose this baseline through shell.nix and rust-toolchain

CI tests now explicitly include 1.50.0