### PR TITLE
Problem: `run_cooperatively` is rather limiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- `single_threaded::yield_timeout` and `single_threaded::yield_animation_frame` API
+  to orchestrate different types of yielding to the environment
+
+### Removed
+
+- `single_threaded::run_cooperatively` is removed in favour of
+  `single_threaded::yield_timeout` and `single_threaded::yield_animation_frame`
+
 ## [0.5.1] - 2021-02-08
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- `single_threaded::yield_timeout` and `single_threaded::yield_animation_frame` API
+- `single_threaded::yield_timeout`, `single_threaded::yield_async` and `single_threaded::yield_animation_frame` API
   to orchestrate different types of yielding to the environment
 
 ### Removed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ futures = { version = "0.3.12", features = ["std"] }
 js-sys = { version = "0.3.47", optional = true }
 pin-project = { version = "1.0.5", optional = true }
 wasm-bindgen = { version = "0.2.70", optional = true }
+web-sys = { version = "0.3.47", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = "0.3"
@@ -30,6 +31,9 @@ default = []
 debug = []
 cooperative = ["js-sys", "wasm-bindgen", "pin-project"]
 cooperative-browser = ["cooperative"]
+# Experimental:
+# https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback
+requestIdleCallback = ["cooperative-browser", "web-sys/IdleDeadline"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["cdylib","lib"]
 [dependencies]
 futures = { version = "0.3.12", features = ["std"] }
 js-sys = { version = "0.3.47", optional = true }
+pin-project = { version = "1.0.5", optional = true }
 wasm-bindgen = { version = "0.2.70", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
@@ -27,7 +28,8 @@ tokio = { version = "1.1.1", features = ["sync", "rt"] }
 [features]
 default = []
 debug = []
-cooperative = ["js-sys", "wasm-bindgen"]
+cooperative = ["js-sys", "wasm-bindgen", "pin-project"]
+cooperative-browser = ["cooperative"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 wasm-bindgen = "0.2.70"
-wasm-rs-async-executor = { path = "..", features = ["cooperative-browser", "debug"] }
+wasm-rs-async-executor = { path = "..", features = ["cooperative-browser", "debug", "requestIdleCallback"] }
 wasm-rs-dbg = "0.1"
 tokio = { version = "1.1", features = ["macros", "time", "sync"] }
 wasm-bindgen-futures = "0.4.20"

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -9,9 +9,10 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 wasm-bindgen = "0.2.70"
-wasm-rs-async-executor = { path = "..", features = ["cooperative"] }
+wasm-rs-async-executor = { path = "..", features = ["cooperative-browser", "debug"] }
 wasm-rs-dbg = "0.1"
 tokio = { version = "1.1", features = ["macros", "time", "sync"] }
 wasm-bindgen-futures = "0.4.20"
-web-sys = { version = "0.3.47", features = ["Window", "Response"] }
+web-sys = { version = "0.3.47", features = ["Window", "Response", "Document", "Element"] }
 js-sys = "0.3.47"
+futures = "0.3.12"

--- a/example/index.html
+++ b/example/index.html
@@ -8,5 +8,12 @@
     <noscript>This page contains webassembly and javascript content, please enable javascript in your browser.</noscript>
     <script src="./bootstrap.js"></script>
     Open console to see the log
+    <h4>task1</h4>
+    <div id="display">
+    </div>
+    <h4>task1x (should stop when task1 is done)</h4>
+    <div id="display1">
+    </div>
+
   </body>
 </html>

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -50,12 +50,12 @@ pub fn start() {
         let response: web_sys::Response = executor::yield_async(fut).await.unwrap().into();
         let text_fut: JsFuture = response.text().unwrap().into();
         dbg!("task 2 will intentionally delay executor by 1 second");
-        let text: String =
-            executor::yield_timeout(Some(std::time::Duration::from_secs(1)), text_fut)
-                .await
-                .unwrap()
-                .as_string()
-                .unwrap();
+        executor::yield_timeout(std::time::Duration::from_secs(1)).await;
+        let text: String = executor::yield_async(text_fut)
+            .await
+            .unwrap()
+            .as_string()
+            .unwrap();
         dbg!(text);
         dbg!("task 2 done");
     });

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -25,7 +25,7 @@ pub fn start() {
         while ctr < 255 {
             element.set_inner_html(&format!("{}", ctr));
             ctr = ctr.wrapping_add(1);
-            executor::yield_animation_frame(async {}).await;
+            executor::yield_animation_frame().await;
         }
     });
     let task1x = executor::spawn(async move {
@@ -36,11 +36,9 @@ pub fn start() {
             .get_element_by_id("display1")
             .unwrap();
 
-        let mut ctr = 0u8;
         loop {
-            element.set_inner_html(&format!("{}", ctr));
-            ctr = ctr.wrapping_add(1);
-            executor::yield_animation_frame(async {}).await;
+            let ts = executor::yield_animation_frame().await;
+            element.set_inner_html(&format!("{}", ts));
         }
     });
 

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -49,8 +49,9 @@ pub fn start() {
         let fut: JsFuture = web_sys::window().unwrap().fetch_with_str("/").into();
         let response: web_sys::Response = executor::yield_async(fut).await.unwrap().into();
         let text_fut: JsFuture = response.text().unwrap().into();
-        dbg!("task 2 will intentionally delay executor by 1 second");
+        dbg!("task 2 will intentionally delay itself by 1 second");
         executor::yield_timeout(std::time::Duration::from_secs(1)).await;
+        dbg!("task 2 wait is over");
         let text: String = executor::yield_async(text_fut)
             .await
             .unwrap()

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -47,7 +47,7 @@ pub fn start() {
         let _ = receiver2.await;
         dbg!("task 2 fetching /");
         let fut: JsFuture = web_sys::window().unwrap().fetch_with_str("/").into();
-        let response: web_sys::Response = executor::yield_timeout(None, fut).await.unwrap().into();
+        let response: web_sys::Response = executor::yield_async(fut).await.unwrap().into();
         let text_fut: JsFuture = response.text().unwrap().into();
         dbg!("task 2 will intentionally delay executor by 1 second");
         let text: String =

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -60,6 +60,12 @@ pub fn start() {
         dbg!(text);
         dbg!("task 2 done");
     });
+
+    let task3 = executor::spawn(async move {
+        dbg!("task 3 awaiting idle browser");
+        executor::yield_until_idle(None).await;
+        dbg!("task 3 is done");
+    });
     dbg!("starting executor, sending to task1");
     let _ = sender1.send(());
     executor::run(Some(task1));

--- a/src/single_threaded.rs
+++ b/src/single_threaded.rs
@@ -165,7 +165,10 @@ where
 /// Run the executor
 ///
 /// If `until` is `None`, it will run until all tasks have been completed. Otherwise, it'll wait
-/// until passed task is complete.
+/// until passed task is complete, or unless a `cooperative` feature has been enabled and control
+/// has been yielded to the environment. In this case the function will return but the environment
+/// might schedule further execution of this executor in the background after termination of the
+/// function enclosing invocation of this [`run`]
 pub fn run(until: Option<Task>) {
     UNTIL.with(|cell| unsafe { *cell.get() = until });
     run_internal();

--- a/src/single_threaded.rs
+++ b/src/single_threaded.rs
@@ -337,6 +337,19 @@ mod cooperative {
         }
     }
 
+    /// Yields to the JavaScript environment using `setTimeout` function
+    ///
+    /// This will return control to the executor once JavaScript envrionment
+    /// invokes the `setTimeout` callback
+    ///
+    /// Only available under `cooperative` feature gate
+    pub fn yield_async<F, O>(future: F) -> impl Future<Output = O>
+    where
+        F: Future<Output = O> + 'static,
+    {
+        yield_timeout(None, future)
+    }
+
     #[cfg(feature = "cooperative-browser")]
     #[pin_project]
     struct AnimationFrameYield {


### PR DESCRIPTION
It only allows to run tasks cooperatively under `setTimeout` and will
always execute just one iteration before yielding back to the browser,
therefore taking control of the behaviour. It would have been nice to
have more control over yielding in the tasks themselves.

Solution: introduce manual yielding primitives
`single_threaded::yield_timeout`, `single_threaded::yield_async` and
`single_threaded::yield_animation_frame`

These functions return futures that first yield to the environment using
`setTimemout` or `requestAnimationFrame`, respectively. These futures
will be ready and will produce the output of the enclosed future (if there's one) once
yielded and those future produced the output.

This allows tasks to control the yielding to a (hopefully) sufficient
degree.

Also, this change saves `until` argument to `run` at the
yield/resume threshold, so the executor will stop if `until` is
specified to be a certain task when that task is done.

---

This PR obsoletes #14 