### PR TITLE
Problem: panics in some yielding futures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Fixed
+
+- `single_threaded::yield_animation_frame` and `single_threaded::yield_until_idle` futures might
+  panic at times
+
 ## [0.6.0] - 2021-02-13
 
 ### Added

--- a/src/single_threaded.rs
+++ b/src/single_threaded.rs
@@ -426,7 +426,7 @@ mod cooperative {
             }
             let should_yield = !self.yielded;
             let this = self.project();
-            if *this.yielded && unsafe { this.output.get().as_ref() }.is_some() {
+            if *this.yielded && unsafe { &*this.output.get() }.is_some() {
                 // it's ok to unwrap here because we check `is_some` above
                 let output = unsafe { &mut *this.output.get() }.take().unwrap();
                 *this.done = true;
@@ -488,7 +488,7 @@ mod cooperative {
             }
             let should_yield = !self.yielded;
             let this = self.project();
-            if *this.yielded && unsafe { this.output.get().as_ref() }.is_some() {
+            if *this.yielded && unsafe { &*this.output.get() }.is_some() {
                 // it's ok to unwrap here because we check `is_some` above
                 let output = unsafe { &mut *this.output.get() }.take().unwrap();
                 *this.done = true;


### PR DESCRIPTION
Particularly, `yield_animation_frame` and `yield_until_idle` might panic
when checking for the ouput, trying to unwrap a value.

Solution: de-reference output before checking it for `is_some()`
instead of taking `as_ref` as that means `is_some()` is checked on the
pointer, not the target value.