### PR TITLE
Problem: figuring out when task is complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- `single_threaded::Task` now implements `std::future::Future` for the purposes
+  of joining task until their completion.
+
 ## [0.7.0] - 2021-02-17
 
 ### Added


### PR DESCRIPTION
This requires either cooperation with the task itself or introspecting
into task list, neither of which is succinct.

Solution: make `Task` implement `Future`
to allow for joining