### PR TITLE
Problem: returning results from tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 ## [Unreleased] - ReleaseDate
 
-### Added
+### Changed
 
-- `single_threaded::Task` now implements `std::future::Future` for the purposes
-  of joining task until their completion.
+- `single_threaded::spawn` now returns `TaskHandle<T>` that allows joining
+  until task completion and retrieval of task's result
+- Tasks are no longer required to return `()`
 
 ## [0.7.0] - 2021-02-17
 


### PR DESCRIPTION
It can be done but requires manual instrumentation of it with a oneshot
channel or something like that.

Solution: instrument all spawned tasks with this approach
and allow joining to retrieve the result

This follows the API pattern in Tokio.