### PR TITLE
Problem: unknown whether it works with WASI

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.wasm32-wasi]
+runner = "wasmtime"

--- a/.cargo/config.wasmer.toml
+++ b/.cargo/config.wasmer.toml
@@ -1,0 +1,2 @@
+[target.wasm32-wasi]
+runner = "wasmer"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -71,9 +71,28 @@ jobs:
         with:
           version: 'latest'
 
-      - name: Check if it builds
+      - name: Use wasmtime 0.23.0
+        uses: mwilliamson/setup-wasmtime-action@v1
+        with:
+          wasmtime-version: "0.23.0"
+
+      - name: Install wasmer
+        run: |-
+          curl https://get.wasmer.io -sSfL | sh
+
+      - name: Check if it tests under Node.js
         run: |-
           wasm-pack test --node -- --all-features
+
+      - name: Check if it tests under wasmtime
+        run: |-
+          cargo test --target wasm32-wasi --all-features
+
+      - name: Check if it tests under wasmer
+        run: |-
+          source ~/.wasmer/wasmer.sh
+          cp .cargo/config.wasmer.toml .cargo/config.toml
+          cargo test --target wasm32-wasi --all-features
 
   lints:
     name: Lints

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+- Continuous integration with `wasm32-wasi` target
+
 ## [0.8.0] - 2021-02-19
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,5 +39,5 @@ requestIdleCallback = ["cooperative-browser", "web-sys/IdleDeadline"]
 all-features = true
 
 [package.metadata.wasm.rs]
-targets = ["wasm32-unknown-unknown"]
+targets = ["wasm32-unknown-unknown", "wasm32-wasi"]
 wasm-readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ work on earlier versions. This hasn't been tested yet.
 
 ## Supported targets
 
-Currently, it's been only tested on `wasm32-unknown-unknown`, but excluding `cooperative` functionality,
-it may work on other wasm32 and non-wasm32 targets. Further testing is to be completed.
+Currently, it's been only tested on `wasm32-unknown-unknown` and, excluding `cooperative` functionality,
+it passes tests under [wasmtime](https://wasmtime.dev/) and [wasmer](https://wasmer.io/) with `wasm32-wasi` target.
+Further testing is to be completed.
 
 ## Notes
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-targets = ["wasm32-unknown-unknown"]
+targets = ["wasm32-unknown-unknown", "wasm32-wasi"]
 components = ["rustfmt", "clippy"]
 channel = "stable"

--- a/shell.nix
+++ b/shell.nix
@@ -3,7 +3,7 @@ let
   pkgs = import <nixpkgs> { overlays = [ moz_overlay ]; };
   rustChannel = (pkgs.rustChannelOf { channel = "stable";  });
   rust = (rustChannel.rust.override {
-    targets = ["wasm32-unknown-unknown"];
+    targets = ["wasm32-unknown-unknown", "wasm32-wasi"];
   });
 in
 pkgs.stdenv.mkDerivation rec {

--- a/src/single_threaded.rs
+++ b/src/single_threaded.rs
@@ -377,7 +377,7 @@ fn run_internal() -> bool {
     })
 }
 
-#[cfg(feature = "cooperative")]
+#[cfg(all(feature = "cooperative", not(target_os = "wasi")))]
 mod cooperative {
     use super::{run_internal, EXIT_LOOP};
     use pin_project::pin_project;
@@ -660,7 +660,7 @@ mod cooperative {
     }
 }
 
-#[cfg(feature = "cooperative")]
+#[cfg(all(feature = "cooperative", not(target_os = "wasi")))]
 pub use cooperative::*;
 
 /// Returns the number of tasks currently registered with the executor
@@ -715,11 +715,11 @@ fn set_counter(counter: usize) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
     use wasm_bindgen_test::*;
 
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(all(target_arch = "wasm32", target_os = "unknown")), test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
     fn test() {
         use tokio::sync::*;
         let (sender, receiver) = oneshot::channel::<()>();
@@ -731,8 +731,8 @@ mod tests {
         evict_all();
     }
 
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(all(target_arch = "wasm32", target_os = "unknown")), test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
     fn test_until() {
         use tokio::sync::*;
         let (_sender1, receiver1) = oneshot::channel::<()>();
@@ -748,8 +748,8 @@ mod tests {
         evict_all();
     }
 
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(all(target_arch = "wasm32", target_os = "unknown")), test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
     fn test_counts() {
         use tokio::sync::*;
         let (sender, mut receiver) = oneshot::channel();
@@ -775,8 +775,8 @@ mod tests {
         evict_all();
     }
 
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(all(target_arch = "wasm32", target_os = "unknown")), test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
     fn evicted_tasks_dont_requeue() {
         use tokio::sync::*;
         let (_sender, receiver) = oneshot::channel::<()>();
@@ -792,8 +792,8 @@ mod tests {
         evict_all();
     }
 
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(all(target_arch = "wasm32", target_os = "unknown")), test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
     fn token_exhaustion() {
         set_counter(usize::MAX);
         // this should be fine anyway
@@ -806,8 +806,8 @@ mod tests {
         evict_all();
     }
 
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(all(target_arch = "wasm32", target_os = "unknown")), test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
     fn blocking_on() {
         use tokio::sync::*;
         let (sender, receiver) = oneshot::channel::<u8>();
@@ -819,8 +819,8 @@ mod tests {
         evict_all();
     }
 
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(all(target_arch = "wasm32", target_os = "unknown")), test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
     fn starvation() {
         use tokio::sync::*;
         let (sender, receiver) = oneshot::channel();
@@ -835,8 +835,8 @@ mod tests {
     }
 
     #[cfg(feature = "debug")]
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(all(target_arch = "wasm32", target_os = "unknown")), test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
     fn task_type_info() {
         spawn(futures::future::pending::<()>());
         assert!(tasks()[0]
@@ -851,8 +851,8 @@ mod tests {
         assert_eq!(tasks().len(), 0);
     }
 
-    #[cfg_attr(not(target_arch = "wasm32"), test)]
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    #[cfg_attr(not(all(target_arch = "wasm32", target_os = "unknown")), test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), wasm_bindgen_test)]
     fn joinining() {
         use tokio::sync::*;
         let (sender, receiver) = oneshot::channel();


### PR DESCRIPTION
Solution: include CI tests for wasi target
using wasmtime and wasmer

This change also makes sure `cooperative` won't be enabled for
`wasm32-wasi` since it's currently specific JavaScript environment.