### PR TITLE
Problem: WASM runtimes' dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,14 @@ crate-type = ["cdylib","lib"]
 
 [dependencies]
 futures = { version = "0.3.12", features = ["std"] }
-js-sys = { version = "0.3.47", optional = true }
 pin-project = { version = "1.0.5", optional = true }
+
+[target.wasm32-unknown-unknown.dependencies]
+js-sys = { version = "0.3.47", optional = true }
 wasm-bindgen = { version = "0.2.70", optional = true }
 web-sys = { version = "0.3.47", optional = true }
 
-[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+[target.wasm32-unknown-unknown.dev-dependencies]
 wasm-bindgen-test = "0.3"
 
 [dev-dependencies]

--- a/src/single_threaded.rs
+++ b/src/single_threaded.rs
@@ -377,7 +377,11 @@ fn run_internal() -> bool {
     })
 }
 
-#[cfg(all(feature = "cooperative", not(target_os = "wasi")))]
+#[cfg(all(
+    feature = "cooperative",
+    target_arch = "wasm32",
+    not(target_os = "wasi")
+))]
 mod cooperative {
     use super::{run_internal, EXIT_LOOP};
     use pin_project::pin_project;
@@ -660,7 +664,11 @@ mod cooperative {
     }
 }
 
-#[cfg(all(feature = "cooperative", not(target_os = "wasi")))]
+#[cfg(all(
+    feature = "cooperative",
+    target_arch = "wasm32",
+    not(target_os = "wasi")
+))]
 pub use cooperative::*;
 
 /// Returns the number of tasks currently registered with the executor


### PR DESCRIPTION
Under certain circumstances, browser or JavaScript related dependencies
might be pulled in for targets like `wasm32-wasi`. This is undesirable.

Solution: separate wasm32-unknown-unknown dependencies