### PR TITLE
Problem: block_on API returns an Option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased] - ReleaseDate
 
+### Changed
+
+- `single_threaded::block_on` returns `R` instead of `Option<R>` now
+
 ## [0.8.1] - 2021-02-20
 
 ### Added


### PR DESCRIPTION
This is confusing (why would it be an Option?).

Solution: make it return the value

It looks like we can pretty much guarantee that the receiver stays
non-dropped during the entire lifetime of `block_on`, hence sending a
oneshot message from the spawned task will be successful and the
receiver will be able to retrieve the data.